### PR TITLE
parabolic box domain chemokine pde framework

### DIFF
--- a/src/AbstractChemokinePde.cpp
+++ b/src/AbstractChemokinePde.cpp
@@ -1,0 +1,116 @@
+/*
+
+Copyright (c) 2005-2020, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "AbstractChemokinePde.hpp"
+#include "ApoptoticCellProperty.hpp"
+#include "CellLabel.hpp"
+
+template<unsigned DIM>
+AbstractChemokinePde<DIM>::AbstractChemokinePde(AbstractCellPopulation<DIM,DIM>& rCellPopulation,
+                                                            double duDtCoefficient,
+                                                            double diffusionCoefficient,
+                                                            double decayRate)
+    : AveragedSourceParabolicPde<DIM>(rCellPopulation,duDtCoefficient,diffusionCoefficient,0.0),
+    m_decayRate(decayRate)
+{
+}
+
+template<unsigned DIM>
+void AbstractChemokinePde<DIM>::SetupSourceTerms(TetrahedralMesh<DIM,DIM>& rCoarseMesh, std::map<CellPtr, unsigned>* pCellPdeElementMap) // must be called before solve
+{
+    // Allocate memory
+    this->mCellDensityOnCoarseElements.resize(rCoarseMesh.GetNumElements());
+    this->mCellDensityOnCoarseElements1.resize(rCoarseMesh.GetNumElements());
+    for (unsigned elem_index=0; elem_index<this->mCellDensityOnCoarseElements.size(); elem_index++)
+    {
+        this->mCellDensityOnCoarseElements[elem_index] = 0.0;
+        this->mCellDensityOnCoarseElements1[elem_index] = 0.0;
+    }
+
+}
+
+template<unsigned DIM>
+double AbstractChemokinePde<DIM>::ComputeDuDtCoefficientFunction(const ChastePoint<DIM>& )
+{
+    return this->mDuDtCoefficient;
+}
+
+template<unsigned DIM>
+double AbstractChemokinePde<DIM>::ComputeSourceTerm(const ChastePoint<DIM>& rX, double u, Element<DIM,DIM>* pElement)
+{
+    assert(!this->mCellDensityOnCoarseElements.empty());
+    assert(!this->mCellDensityOnCoarseElements1.empty());
+    double source_coefficient = this->mCellDensityOnCoarseElements[pElement->GetIndex()];
+    double consumption_coefficient = this->mCellDensityOnCoarseElements1[pElement->GetIndex()];
+    // The source term is rho(x)*mSourceCoefficient - mDecayRate*u
+    return source_coefficient + consumption_coefficient * u - m_decayRate * u;
+}
+
+// LCOV_EXCL_START
+template<unsigned DIM>
+double AbstractChemokinePde<DIM>::ComputeSourceTermAtNode(const Node<DIM>& rNode, double u)
+{
+    NEVER_REACHED;
+    return 0.0;
+}
+// LCOV_EXCL_STOP
+
+template<unsigned DIM>
+c_matrix<double,DIM,DIM> AbstractChemokinePde<DIM>::ComputeDiffusionTerm(const ChastePoint<DIM>& rX, Element<DIM,DIM>* pElement)
+{
+    return this->mDiffusionCoefficient*identity_matrix<double>(DIM);
+}
+
+template<unsigned DIM>
+double AbstractChemokinePde<DIM>::GetUptakeRateForElement(unsigned elementIndex)
+{
+    this->mCellDensityOnCoarseElements[elementIndex];
+    return this->mCellDensityOnCoarseElements[elementIndex];
+}
+
+template <unsigned DIM>
+double AbstractChemokinePde<DIM>::GetDecayRate() const
+{
+    return m_decayRate;
+}
+
+// Explicit instantiation
+template class AbstractChemokinePde<1>;
+template class AbstractChemokinePde<2>;
+template class AbstractChemokinePde<3>;
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(AbstractChemokinePde)

--- a/src/AbstractChemokinePde.hpp
+++ b/src/AbstractChemokinePde.hpp
@@ -1,0 +1,209 @@
+/*
+
+Copyright (c) 2005-2020, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TCELLABM_PDE_ABSTRACT_CHEMOKINE_PDE_HPP
+#define TCELLABM_PDE_ABSTRACT_CHEMOKINE_PDE_HPP
+
+#include "ChasteSerialization.hpp"
+#include <boost/serialization/base_object.hpp>
+
+#include "AbstractCellPopulation.hpp"
+#include "AbstractCellProperty.hpp"
+#include "TetrahedralMesh.hpp"
+#include "AveragedSourceParabolicPde.hpp"
+#include "NodeBasedCellPopulation.hpp"
+
+/**
+ * A parabolic PDE to be solved numerically using the finite element method, for
+ * coupling to a cell-based simulation.
+ *
+ * The PDE takes the form
+ *
+ * c*du/dt = Grad.(D*Grad(u)) + k*u*rho(x),
+ *
+ * where the scalars c, D and k are specified by the members mDuDtCoefficient,
+ * mDiffusionCoefficient and mSourceCoefficient, respectively. Their values must
+ * be set in the constructor.
+ *
+ * The function rho(x) denotes the local density of non-apoptotic cells. This
+ * quantity is computed for each element of a 'coarse' finite element mesh that is
+ * passed to the method SetupSourceTerms() and stored in the member mCellDensityOnCoarseElements.
+ * For a point x, rho(x) is defined to be the number of non-apoptotic cells whose
+ * centres lie in each finite element containing that point, scaled by the area of
+ * that element.
+ */
+template<unsigned DIM>
+class AbstractChemokinePde : public AveragedSourceParabolicPde<DIM>
+{
+    friend class TestCellBasedParabolicPdes;
+
+private:
+
+    /** Needed for serialization.*/
+    friend class boost::serialization::access;
+    /**
+     * Serialize the PDE and its member variables.
+     *
+     * @param archive the archive
+     * @param version the current version of this class
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+       archive & boost::serialization::base_object<AveragedSourceParabolicPde<DIM> >(*this);
+       archive & m_decayRate;
+       archive & mCellDensityOnCoarseElements1;
+    }
+
+protected:
+    
+    double m_decayRate;
+
+    std::vector<double> mCellDensityOnCoarseElements1;
+
+public:
+
+    /**
+     * Constructor.
+     *
+     * @param rCellPopulation reference to the cell population
+     * @param duDtCoefficient rate of reaction (defaults to 1.0)
+     * @param diffusionCoefficient rate of diffusion (defaults to 1.0)
+     * @param decayRate rate of decay (defaults to 0.1)
+     */
+    AbstractChemokinePde(AbstractCellPopulation<DIM, DIM>& rCellPopulation,
+                               double duDtCoefficient=1.0,
+                               double diffusionCoefficient=1.0,
+                               double decayRate=0.1);
+
+    /**
+     * Set up the source terms.
+     *
+     * \todo this is identical to the one in AveragedSourceEllipticPde so refactor.
+     *
+     * @param rCoarseMesh reference to the coarse mesh
+     * @param pCellPdeElementMap optional pointer to the map from cells to coarse elements
+     */
+    void SetupSourceTerms(TetrahedralMesh<DIM,DIM>& rCoarseMesh, std::map<CellPtr, unsigned>* pCellPdeElementMap=nullptr);
+
+    /**
+     * Overridden ComputeDuDtCoefficientFunction() method.
+     *
+     * @return the function c(x) in "c(x) du/dt = Grad.(DiffusionTerm(x)*Grad(u))+LinearSourceTerm(x)+NonlinearSourceTerm(x, u)"
+     *
+     * @param rX the point in space at which the function c is computed
+     */
+    virtual double ComputeDuDtCoefficientFunction(const ChastePoint<DIM>& rX);
+
+    /**
+     * Overridden ComputeSourceTerm() method.
+     *
+     * @return computed source term.
+     *
+     * @param rX the point in space at which the nonlinear source term is computed
+     * @param u the value of the dependent variable at the point
+     * @param pElement the mesh element that x is contained in (optional; defaults to NULL).
+     */
+    virtual double ComputeSourceTerm(const ChastePoint<DIM>& rX,
+                                     double u,
+                                     Element<DIM,DIM>* pElement=NULL);
+
+    /**
+     * Overridden ComputeSourceTermAtNode() method. That is never called.
+     *
+     * @return computed source term at a node.
+     *
+     * @param rNode the node at which the nonlinear source term is computed
+     * @param u the value of the dependent variable at the node
+     */
+    virtual double ComputeSourceTermAtNode(const Node<DIM>& rNode, double u);
+
+    /**
+     * Overridden ComputeDiffusionTerm() method.
+     *
+     * @param rX the point in space at which the diffusion term is computed
+     * @param pElement the mesh element that x is contained in (optional; defaults to NULL).
+     *
+     * @return a matrix.
+     */
+    virtual c_matrix<double,DIM,DIM> ComputeDiffusionTerm(const ChastePoint<DIM>& rX, Element<DIM,DIM>* pElement=NULL);
+
+    /**
+     * @return the uptake rate.
+     *
+     * @param elementIndex the element we wish to return the uptake rate for
+     */
+    double GetUptakeRateForElement(unsigned elementIndex);
+
+    double GetDecayRate() const;
+};
+
+#include "SerializationExportWrapper.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(AbstractChemokinePde)
+
+namespace boost
+{
+namespace serialization
+{
+/**
+ * Serialize information required to construct a AveragedSourceParabolicPde.
+ */
+template<class Archive, unsigned DIM>
+inline void save_construct_data(
+    Archive & ar, const AbstractChemokinePde<DIM>* t, const unsigned int file_version)
+{
+    // Save data required to construct instance
+    const AbstractCellPopulation<DIM, DIM>* p_cell_population = &(t->rGetCellPopulation());
+    ar & p_cell_population;
+}
+
+/**
+ * De-serialize constructor parameters and initialise a AveragedSourceParabolicPde.
+ */
+template<class Archive, unsigned DIM>
+inline void load_construct_data(
+    Archive & ar, AbstractChemokinePde<DIM>* t, const unsigned int file_version)
+{
+    // Retrieve data from archive required to construct new instance
+    AbstractCellPopulation<DIM, DIM>* p_cell_population;
+    ar >> p_cell_population;
+
+    // Invoke inplace constructor to initialise instance
+    ::new(t)AbstractChemokinePde<DIM>(*p_cell_population);
+}
+}
+} // namespace ...
+
+#endif /*TCELLABM_PDE_ABSTRACT_CHEMOKINE_PDE_HPP*/

--- a/src/CXCL8Pde.cpp
+++ b/src/CXCL8Pde.cpp
@@ -1,0 +1,110 @@
+/*
+
+Copyright (c) 2005-2020, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "CXCL8Pde.hpp"
+
+#include "MetCellProliferativeType.hpp"
+#include "NeutrophilProliferativeType.hpp"
+#include "ApoptoticCellProperty.hpp"
+#include "CellLabel.hpp"
+
+template<unsigned DIM>
+CXCL8Pde<DIM>::CXCL8Pde(AbstractCellPopulation<DIM,DIM>& rCellPopulation, double duDtCoefficient, double diffusionCoefficient,
+        double decayRate,
+        double sourceCoefficient,
+        double consumptionCoefficient) :
+    AbstractChemokinePde<DIM>(rCellPopulation,duDtCoefficient,diffusionCoefficient, decayRate),
+    m_sourceCoefficient(sourceCoefficient),
+    m_consumptionCoefficient(consumptionCoefficient)
+{
+}
+
+template<unsigned DIM>
+void CXCL8Pde<DIM>::SetupSourceTerms(TetrahedralMesh<DIM,DIM>& rCoarseMesh, std::map<CellPtr, unsigned>* pCellPdeElementMap) // must be called before solve
+{
+    AbstractChemokinePde<DIM>::SetupSourceTerms(rCoarseMesh, pCellPdeElementMap);
+
+    // Loop over cells, find which coarse element it is in, and add 1 to mSourceTermOnCoarseElements[elem_index]
+    for (typename AbstractCellPopulation<DIM>::Iterator cell_iter = this->mrCellPopulation.Begin();
+         cell_iter != this->mrCellPopulation.End();
+         ++cell_iter)
+    {
+        unsigned elem_index = 0;
+        const ChastePoint<DIM>& r_position_of_cell = this->mrCellPopulation.GetLocationOfCellCentre(*cell_iter);
+
+        if (pCellPdeElementMap != nullptr)
+        {
+            elem_index = (*pCellPdeElementMap)[*cell_iter];
+        }
+        else
+        {
+            elem_index = rCoarseMesh.GetContainingElementIndex(r_position_of_cell);
+        }
+
+        if (!cell_iter->template HasCellProperty<ApoptoticCellProperty>())
+        {
+            // Count Source Cells
+            if (cell_iter->GetCellProliferativeType()->template IsType<MetCellProliferativeType>())
+            {
+                this->mCellDensityOnCoarseElements[elem_index] += 1.0;
+            }
+            // Count Consumption Cells
+            if (cell_iter->GetCellProliferativeType()->template IsType<NeutrophilProliferativeType>())
+            {
+                this->mCellDensityOnCoarseElements1[elem_index] += 1.0;
+            }
+        }
+    }
+
+    // Then divide each entry of mSourceTermOnCoarseElements by the element's area
+    c_matrix<double, DIM, DIM> jacobian;
+    double det;
+    for (unsigned elem_index=0; elem_index<this->mCellDensityOnCoarseElements.size(); elem_index++)
+    {
+        rCoarseMesh.GetElement(elem_index)->CalculateJacobian(jacobian, det);
+        this->mCellDensityOnCoarseElements[elem_index] /= rCoarseMesh.GetElement(elem_index)->GetVolume(det);
+        this->mCellDensityOnCoarseElements1[elem_index] /= rCoarseMesh.GetElement(elem_index)->GetVolume(det);
+    }
+}
+
+
+// Explicit instantiation
+template class CXCL8Pde<1>;
+template class CXCL8Pde<2>;
+template class CXCL8Pde<3>;
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(CXCL8Pde)

--- a/src/CXCL8Pde.hpp
+++ b/src/CXCL8Pde.hpp
@@ -1,0 +1,148 @@
+/*
+
+Copyright (c) 2005-2020, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef LIVERMETS_CXCL8_PDE_HPP
+#define LIVERMETS_CXCL8_PDE_HPP
+
+#include "ChasteSerialization.hpp"
+#include <boost/serialization/base_object.hpp>
+
+#include "AbstractChemokinePde.hpp"
+
+/**
+ * A parabolic PDE to be solved numerically using the finite element method, for
+ * coupling to a cell-based simulation.
+ *
+ * The PDE takes the form
+ *
+ * c*du/dt = Grad.(D*Grad(u)) + k*u*rho(x),
+ *
+ * where the scalars c, D and k are specified by the members mDuDtCoefficient,
+ * mDiffusionCoefficient and mSourceCoefficient, respectively. Their values must
+ * be set in the constructor.
+ *
+ * The function rho(x) denotes the local density of non-apoptotic cells. This
+ * quantity is computed for each element of a 'coarse' finite element mesh that is
+ * passed to the method SetupSourceTerms() and stored in the member mCellDensityOnCoarseElements.
+ * For a point x, rho(x) is defined to be the number of non-apoptotic cells whose
+ * centres lie in each finite element containing that point, scaled by the area of
+ * that element.
+ */
+template<unsigned DIM>
+class CXCL8Pde : public AbstractChemokinePde<DIM>
+{
+    friend class TestCellBasedParabolicPdes;
+
+private:
+
+    /** Needed for serialization.*/
+    friend class boost::serialization::access;
+    /**
+     * Serialize the PDE and its member variables.
+     *
+     * @param archive the archive
+     * @param version the current version of this class
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+       archive & boost::serialization::base_object<AbstractChemokinePde<DIM> >(*this);
+    }
+
+protected:
+
+    double m_sourceCoefficient;
+    double m_consumptionCoefficient;
+
+public:
+
+    /**
+     * Constructor.
+     *
+     * @param rCellPopulation reference to the cell population
+     * @param duDtCoefficient rate of reaction (defaults to 1.0)
+     * @param diffusionCoefficient rate of diffusion (defaults to 1.0)
+     * @param decayRate rate of decay (defaults to 0.1)
+     * @param sourceCoefficient source term coefficient (defaults to 0.0)
+     * @param consumptionCoefficient receptor uptake coefficient (defaults to 0.0)
+     */
+    CXCL8Pde(AbstractCellPopulation<DIM, DIM>& rCellPopulation,
+                               double duDtCoefficient=1.0,
+                               double diffusionCoefficient=1.0,
+                               double decayRate=0.0,
+                               double sourceCoefficient=1.0,
+                               double consumptionCoefficient=0.03);
+
+    /**
+     * Set up the source terms.
+     *
+     * \todo this is identical to the one in AveragedSourceEllipticPde so refactor.
+     *
+     * @param rCoarseMesh reference to the coarse mesh
+     * @param pCellPdeElementMap optional pointer to the map from cells to coarse elements
+     */
+    void SetupSourceTerms(TetrahedralMesh<DIM,DIM>& rCoarseMesh, std::map<CellPtr, unsigned>* pCellPdeElementMap=nullptr);
+
+};
+
+#include "SerializationExportWrapper.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(CXCL8Pde)
+
+namespace boost
+{
+namespace serialization
+{
+/**
+ * Serialize rParamsfilel_population;
+}
+
+/**
+ * De-serialize constructor parameters and initialise a AveragedSourceParabolicPde.
+ */
+template<class Archive, unsigned DIM>
+inline void load_construct_data(
+    Archive & ar, CXCL8Pde<DIM>* t, const unsigned int file_version)
+{
+    // Retrieve data from archive required to construct new instance
+    AbstractCellPopulation<DIM, DIM>* p_cell_population;
+    ar >> p_cell_population;
+
+    // Invoke inplace constructor to initialise instance
+    ::new(t)CXCL8Pde<DIM>(*p_cell_population);
+}
+}
+} // namespace ...
+
+#endif /*LIVERMETS_CXCL8_PDE_HPP*/

--- a/test/ContinuousTestPack.txt
+++ b/test/ContinuousTestPack.txt
@@ -3,3 +3,4 @@ TestChaste.hpp
 TestLiverMetCellTypes.hpp
 TestCellTypesAndPde.hpp
 TestMetDomain.hpp
+TestMetDomainParabolicPde.hpp

--- a/test/TestMetDomainParabolicPde.hpp
+++ b/test/TestMetDomainParabolicPde.hpp
@@ -1,0 +1,219 @@
+#include <cxxtest/TestSuite.h>
+#include "CheckpointArchiveTypes.hpp"
+#include "AbstractCellBasedTestSuite.hpp"
+#include "HoneycombMeshGenerator.hpp"
+#include "HoneycombVertexMeshGenerator.hpp"
+#include "NodeBasedCellPopulation.hpp"
+#include "OffLatticeSimulation.hpp"
+#include "VertexBasedCellPopulation.hpp"
+#include "NagaiHondaForce.hpp"
+#include "SimpleTargetAreaModifier.hpp"
+#include "GeneralisedLinearSpringForce.hpp"
+#include "DifferentiatedCellProliferativeType.hpp"
+#include "WildTypeCellMutationState.hpp"
+#include "CellAgesWriter.hpp"
+#include "CellIdWriter.hpp"
+#include "CellProliferativePhasesWriter.hpp"
+#include "CellVolumesWriter.hpp"
+#include "CellMutationStatesCountWriter.hpp"
+#include "CellProliferativePhasesCountWriter.hpp"
+#include "CellProliferativeTypesCountWriter.hpp"
+#include "SmartPointers.hpp"
+#include "PetscSetupAndFinalize.hpp"
+#include "UniformG1GenerationalCellCycleModel.hpp"
+#include "DeltaNotchSrnModel.hpp"
+#include "DeltaNotchTrackingModifier.hpp"
+#include "PlaneBoundaryCondition.hpp"
+
+//new celltypes
+#include "TCellProliferativeType.hpp"
+#include "MetCellProliferativeType.hpp"
+#include "NeutrophilProliferativeType.hpp"
+#include "FibroblastProliferativeType.hpp"
+#include "BackgroundCellProliferativeType.hpp"
+#include "SimpleLiverMetCellCycleModel.hpp"
+
+//oxygen pde
+#include "TumourCellwiseSourceEllipticPde.hpp"
+#include "ConstBoundaryCondition.hpp"
+#include "EllipticGrowingDomainPdeModifier.hpp"
+#include "ParabolicBoxDomainPdeModifier.hpp"
+#include "CXCL8Pde.hpp"
+
+//new force models
+#include "RandomMotionForce.hpp"
+
+//new cell killer
+#include "TypeDependentKiller.hpp"
+
+
+class TestMetDomainParabolic: public AbstractCellBasedTestSuite
+{
+public:
+
+     //Set up some global variables - (not accurate cell cycle periods)
+    double minTcellCycleDurationTime = 10;
+    double maxTcellCycleDurationTime = 36;
+
+    double minMetcellCycleDurationTime = 8;
+    double maxMetcellCycleDurationTime = 12;
+
+    double minNeutrophilCycleDurationTime = 10;
+    double maxNeutrophilCycleDurationTime = 36;
+
+    double minFibroblastCycleDurationTime = 10;
+    double maxFibroblastCycleDurationTime = 36;
+
+    double randPertScale=0.01;
+
+    double initial_tumour_radius=1.5;
+    int DomainSize = 27;
+
+
+    void TestDomainParabolic()
+    {
+        HoneycombMeshGenerator generator(DomainSize, DomainSize);
+        boost::shared_ptr<MutableMesh<2,2> > p_generating_mesh = generator.GetMesh();
+        NodesOnlyMesh<2> mesh;
+        mesh.ConstructNodesWithoutMesh(*p_generating_mesh, 1);
+
+        std::vector<CellPtr> cells;
+        MAKE_PTR(WildTypeCellMutationState, p_state);
+        MAKE_PTR(TCellProliferativeType, p_T_type);
+        MAKE_PTR(MetCellProliferativeType, p_met_type);
+        MAKE_PTR(NeutrophilProliferativeType, p_neu_type);
+        MAKE_PTR(FibroblastProliferativeType, p_fib_type);
+        MAKE_PTR(BackgroundCellProliferativeType, p_Background_type);
+
+        c_vector<double,2> centre = zero_vector<double>(2);
+        centre(0)=DomainSize/2;
+        centre(1)=DomainSize/2;
+
+        for (unsigned i=0; i<mesh.GetNumNodes(); i++)
+        {
+            //give each cell a cell cycle model
+            SimpleLiverMetCellCycleModel* p_cc_model = new SimpleLiverMetCellCycleModel();
+            p_cc_model->SetMinCellCycleDurationForTCell(minTcellCycleDurationTime); //edit some cell cycle properties
+            p_cc_model->SetMaxCellCycleDurationForTCell(maxTcellCycleDurationTime);
+
+            p_cc_model->SetMinCellCycleDurationForMetCell(minMetcellCycleDurationTime); //edit some cell cycle properties
+            p_cc_model->SetMaxCellCycleDurationForMetCell(maxMetcellCycleDurationTime);
+
+            p_cc_model->SetMinCellCycleDurationForNeutrophil(minNeutrophilCycleDurationTime); //edit some cell cycle properties
+            p_cc_model->SetMaxCellCycleDurationForNeutrophil(maxNeutrophilCycleDurationTime);
+
+            p_cc_model->SetMinCellCycleDurationForFibroblast(minFibroblastCycleDurationTime); //edit some cell cycle properties
+            p_cc_model->SetMaxCellCycleDurationForFibroblast(maxFibroblastCycleDurationTime);
+
+            p_cc_model->SetDimension(2);
+            CellPtr p_cell(new Cell(p_state,p_cc_model));
+
+            c_vector<double, 2> this_node_location = mesh.GetNode(i)->rGetLocation();
+            double dist_to_centre = norm_2(this_node_location-centre);
+            double cxcl8_initial_value = 0;
+            if (dist_to_centre<initial_tumour_radius)
+            {
+                p_cell->SetCellProliferativeType(p_met_type);
+                double birth_time = -RandomNumberGenerator::Instance()->ranf()*12.0;
+                p_cell->SetBirthTime(birth_time);
+                cxcl8_initial_value = 1;
+            }
+            else if (dist_to_centre>4*initial_tumour_radius && dist_to_centre<=6*initial_tumour_radius)
+            {   
+                double random_number=RandomNumberGenerator::Instance()->ranf();
+                if (random_number<0.2)
+                { //include some immune cells separated from the initial tumour mass
+                    p_cell->SetCellProliferativeType(p_neu_type);
+                    double birth_time = -RandomNumberGenerator::Instance()->ranf()*12.0;
+                    p_cell->SetBirthTime(birth_time);
+                }
+                else if (random_number>=0.2 && random_number<0.4)
+                {
+                    p_cell->SetCellProliferativeType(p_T_type);
+                    double birth_time = -RandomNumberGenerator::Instance()->ranf()*12.0;
+                    p_cell->SetBirthTime(birth_time); 
+                }
+                else
+                {
+                    p_cell->SetCellProliferativeType(p_Background_type);
+                    double birth_time = 0;
+                    p_cell->SetBirthTime(birth_time);   
+                }
+            }
+            else
+            {
+                p_cell->SetCellProliferativeType(p_Background_type);
+                double birth_time = 0; // this doesn't matter because these cells don't proliferate
+                p_cell->SetBirthTime(birth_time);
+            }
+            p_cell->GetCellData()->SetItem("CXCL8", cxcl8_initial_value);
+            cells.push_back(p_cell);
+        }
+
+        NodeBasedCellPopulation<2> cell_population(mesh, cells);
+
+        //add writer to visualise some cell properties
+        cell_population.AddCellPopulationCountWriter<CellProliferativeTypesCountWriter>();
+        cell_population.AddCellWriter<CellIdWriter>();
+        cell_population.AddCellWriter<CellAgesWriter>();
+
+        OffLatticeSimulation<2> simulator(cell_population);
+        simulator.SetOutputDirectory("TestMetDomain");
+        simulator.SetSamplingTimestepMultiple(10);
+        simulator.SetEndTime(10.0);
+
+        MAKE_PTR(GeneralisedLinearSpringForce<2>, p_force);
+        p_force->SetCutOffLength(1.5);
+        simulator.AddForce(p_force);
+
+        //add bounding box to simulation - no upper bound
+        c_vector<double,2> point = zero_vector<double>(2);
+        c_vector<double,2> normal = zero_vector<double>(2);
+        normal(0) = -1.0;
+        MAKE_PTR_ARGS(PlaneBoundaryCondition<2>, p_bc1, (&cell_population, point, normal));
+        simulator.AddCellPopulationBoundaryCondition(p_bc1);
+        point(0) = DomainSize;
+        normal(0) = 1.0;
+        MAKE_PTR_ARGS(PlaneBoundaryCondition<2>, p_bc2, (&cell_population, point, normal));
+        simulator.AddCellPopulationBoundaryCondition(p_bc2);
+        point(0) = 0.0;
+        point(1) = 0.0;
+        normal(0) = 0.0;
+        normal(1) = -1.0;
+        MAKE_PTR_ARGS(PlaneBoundaryCondition<2>, p_bc3, (&cell_population, point, normal));
+        simulator.AddCellPopulationBoundaryCondition(p_bc3);
+        point(1) = DomainSize;
+        normal(1) = 1.0;
+        MAKE_PTR_ARGS(PlaneBoundaryCondition<2>, p_bc4, (&cell_population, point, normal));
+        simulator.AddCellPopulationBoundaryCondition(p_bc4);
+
+        //TODO: add an force 
+        //MAKE_PTR(RandomMotionForce<2>, p_random_force);
+        //p_random_force->SetMovementParameter(randPertScale);
+        //simulator.AddForce(p_random_force);
+
+        //add a pde - MODIFY THIS PDE 
+        MAKE_PTR_ARGS(CXCL8Pde<2>, p_pde, (cell_population,
+                                        /*DuDt*/ 1.0,
+                                        /*Diffusion*/ 1,
+                                        /*Decay*/ 0.3,
+                                        /*Source*/ 7.5,
+                                        /*Consumption*/ 1));
+        MAKE_PTR_ARGS(ConstBoundaryCondition<2>, p_bc, (0.0));
+        bool is_neumann_bc = true;
+        ChastePoint<2> lower(0, 0, 0);
+        ChastePoint<2> upper(DomainSize, DomainSize, 0);
+        boost::shared_ptr<ChasteCuboid<2>> p_domain = boost::make_shared<ChasteCuboid<2> >(lower, upper);
+        MAKE_PTR_ARGS(ParabolicBoxDomainPdeModifier<2>, p_pde_modifier,
+                  (p_pde, p_bc, is_neumann_bc, p_domain, 1.0));
+        p_pde_modifier->SetDependentVariableName("CXCL8");
+        p_pde_modifier->SetBcsOnBoxBoundary(true);
+        simulator.AddSimulationModifier(p_pde_modifier);
+
+        //add a cell killer - MODIFY THIS KILLER
+        MAKE_PTR_ARGS(TypeDependentKiller<2>, p_killer,(&cell_population));
+        simulator.AddCellKiller(p_killer); 
+
+        simulator.Solve();
+    }
+};

--- a/test/TestMetDomainParabolicPde.hpp
+++ b/test/TestMetDomainParabolicPde.hpp
@@ -158,7 +158,7 @@ public:
         cell_population.AddCellWriter<CellAgesWriter>();
 
         OffLatticeSimulation<2> simulator(cell_population);
-        simulator.SetOutputDirectory("TestMetDomain");
+        simulator.SetOutputDirectory("TestMetDomainParabolicPde");
         simulator.SetSamplingTimestepMultiple(10);
         simulator.SetEndTime(10.0);
 

--- a/test/TestMetDomainParabolicPde.hpp
+++ b/test/TestMetDomainParabolicPde.hpp
@@ -208,6 +208,7 @@ public:
                   (p_pde, p_bc, is_neumann_bc, p_domain, 1.0));
         p_pde_modifier->SetDependentVariableName("CXCL8");
         p_pde_modifier->SetBcsOnBoxBoundary(true);
+        p_pde_modifier->SetOutputGradient(true);
         simulator.AddSimulationModifier(p_pde_modifier);
 
         //add a cell killer - MODIFY THIS KILLER


### PR DESCRIPTION
Some framework classes for adding chemokines with options for source, consumption and decay of chemokine.
Implemented CXCL8 PDE as example, tumour cell sources, neutrophil sinks with decay of CXCL8.
Example in tests/TestMetDomainParabolicPde